### PR TITLE
adds notes on icon images for macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ Copy the `.icns` file you'd like to use. Find VS Code in your Applications folde
 
 If for some reason that doesn't work, then dragging the `.icns` to the icon (in the top left) of the info pane, until you see the green plus sign and then dropping it works.
 
+*Important Notes*  
+Once you have added the desired image, you may *delete* the source image after the icon has changes as OS X - Mojave are able to save this information without using the image path.
+
+
 **Windows:**
 
 Right click on the shortcut App Icon, select properties and then shortcut tab and then `change icon` button.


### PR DESCRIPTION
in reference to the issue previously written, I have attached some small notes for macos users to make the wording a bit easier, as well as alleviate concern for those who are short on memory space for their macbooks